### PR TITLE
MARMOTTA-500: Add "x within y" node selector for working with HTTP RDF sources with inlined resources

### DIFF
--- a/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/api/LDCachingService.java
+++ b/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/api/LDCachingService.java
@@ -17,6 +17,7 @@
 package org.apache.marmotta.ldcache.api;
 
 import org.openrdf.model.Model;
+import org.openrdf.model.Resource;
 import org.openrdf.model.URI;
 
 import java.util.Collection;
@@ -90,7 +91,7 @@ public interface LDCachingService {
      * @param options options for refreshing
      * @return temporary URI that can be used to access the data
      */
-    URI createSubjectForResourceWithinRequest(URI requestUri, URI subject, RefreshOpts... options);
+    URI createSubjectForResourceWithinRequest(URI requestUri, Resource subject, RefreshOpts... options);
 
 
     public enum RefreshOpts {

--- a/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/api/LDCachingService.java
+++ b/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/api/LDCachingService.java
@@ -19,6 +19,8 @@ package org.apache.marmotta.ldcache.api;
 import org.openrdf.model.Model;
 import org.openrdf.model.URI;
 
+import java.util.Collection;
+
 /**
  * This is the next-generation API for LDCache that will become the default in Marmotta 3.3 or 4.0. For now,
  * LDCache implements both the old and the new style.
@@ -81,12 +83,22 @@ public interface LDCachingService {
     public void shutdown();
 
 
+    /**
+     * Create a temporary resource for a subject provided by a different linked data resource
+     * @param requestUri the resource to request
+     * @param subject subject within the resource to retrieve
+     * @param options options for refreshing
+     * @return temporary URI that can be used to access the data
+     */
+    URI createSubjectForResourceWithinRequest(URI requestUri, URI subject, RefreshOpts... options);
+
 
     public enum RefreshOpts {
 
         /**
          * Refresh the resource even if it is not yet expired
          */
-        FORCE
+        FORCE,
+        IGNORE_LOCKS
     }
 }

--- a/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/model/CacheEntry.java
+++ b/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/model/CacheEntry.java
@@ -22,7 +22,9 @@ import org.openrdf.model.Model;
 import org.openrdf.model.URI;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /**
  * The cache entry for a URI resource managed by the Linked Data Cache. Contains maintenance information about
@@ -61,8 +63,11 @@ public class CacheEntry implements Serializable {
      */
     private Integer tripleCount;
 
+    private List<URI> skolemizedResources;
+
 
     public CacheEntry() {
+        skolemizedResources = new ArrayList<>();
     }
 
 
@@ -150,6 +155,9 @@ public class CacheEntry implements Serializable {
         this.triples = triples;
     }
 
+    public void addSkolemizedResource(URI uri) { this.skolemizedResources.add(uri); }
+
+    public List<URI> getSkolemizedResources() { return this.skolemizedResources; }
 
     @Override
     public String toString() {

--- a/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/model/CacheEntry.java
+++ b/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/model/CacheEntry.java
@@ -63,11 +63,10 @@ public class CacheEntry implements Serializable {
      */
     private Integer tripleCount;
 
-    private List<URI> skolemizedResources;
+    private URI parentResource;
 
 
     public CacheEntry() {
-        skolemizedResources = new ArrayList<>();
     }
 
 
@@ -155,9 +154,8 @@ public class CacheEntry implements Serializable {
         this.triples = triples;
     }
 
-    public void addSkolemizedResource(URI uri) { this.skolemizedResources.add(uri); }
-
-    public List<URI> getSkolemizedResources() { return this.skolemizedResources; }
+    public void setParentResource(URI uri) { this.parentResource = uri; }
+    public URI getParentResource() { return this.parentResource; }
 
     @Override
     public String toString() {

--- a/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/model/CacheEntry.java
+++ b/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/model/CacheEntry.java
@@ -19,6 +19,7 @@ package org.apache.marmotta.ldcache.model;
 
 import org.apache.marmotta.commons.util.DateUtils;
 import org.openrdf.model.Model;
+import org.openrdf.model.Resource;
 import org.openrdf.model.URI;
 
 import java.io.Serializable;
@@ -38,7 +39,7 @@ public class CacheEntry implements Serializable {
     /**
      * The URI resource managed by this cache entry.
      */
-    private URI resource;
+    private Resource resource;
 
     /**
      * The date when this resource has been retrieved the last time.
@@ -73,14 +74,14 @@ public class CacheEntry implements Serializable {
     /**
      * The URI resource managed by this cache entry.
      */
-    public URI getResource() {
+    public Resource getResource() {
         return resource;
     }
 
     /**
      * The URI resource managed by this cache entry.
      */
-    public void setResource(URI resource) {
+    public void setResource(Resource resource) {
         this.resource = resource;
     }
 

--- a/libraries/ldcache/ldcache-backend-file/src/main/java/org/apache/marmotta/ldcache/backend/file/util/FileBackendUtils.java
+++ b/libraries/ldcache/ldcache-backend-file/src/main/java/org/apache/marmotta/ldcache/backend/file/util/FileBackendUtils.java
@@ -19,6 +19,7 @@ package org.apache.marmotta.ldcache.backend.file.util;
 
 import org.apache.marmotta.commons.util.HashUtils;
 import org.apache.marmotta.ldcache.model.CacheEntry;
+import org.openrdf.model.Resource;
 import org.openrdf.model.URI;
 import org.openrdf.model.ValueFactory;
 
@@ -36,7 +37,7 @@ public class FileBackendUtils {
 		// static access only
 	}
 
-	public static File getMetaFile(URI resource, File baseDir) {
+	public static File getMetaFile(Resource resource, File baseDir) {
 		return getMetaFile(resource.stringValue(), baseDir);
 	}
 

--- a/libraries/ldcache/ldcache-core/src/main/java/org/apache/marmotta/ldcache/services/LDCache.java
+++ b/libraries/ldcache/ldcache-core/src/main/java/org/apache/marmotta/ldcache/services/LDCache.java
@@ -27,6 +27,7 @@ import org.apache.marmotta.ldclient.exception.DataRetrievalException;
 import org.apache.marmotta.ldclient.model.ClientResponse;
 import org.apache.marmotta.ldclient.services.ldclient.LDClient;
 import org.openrdf.model.Model;
+import org.openrdf.model.Resource;
 import org.openrdf.model.URI;
 import org.openrdf.model.impl.TreeModel;
 import org.openrdf.model.impl.ValueFactoryImpl;
@@ -187,7 +188,7 @@ public class LDCache implements LDCachingService {
             if (parentResource != null) {
                 final Model statements = get(parentResource, options);
 
-                statements.setNamespace(SMUGGLED_ORIGINAL_RESOURCE_ID, entry.getResource().stringValue());
+                statements.add(resource, OWL.SAMEAS, entry.getResource());
 
                 return statements;
             } else {
@@ -244,7 +245,7 @@ public class LDCache implements LDCachingService {
      * @return temporary URI that can be used to access the data
      */
     @Override
-    public URI createSubjectForResourceWithinRequest(URI requestUri, URI subject, RefreshOpts... options) {
+    public URI createSubjectForResourceWithinRequest(URI requestUri, Resource subject, RefreshOpts... options) {
         final String localName = String.valueOf(requestUri.hashCode() + subject.hashCode());
 
         resourceLocks.lock(localName);

--- a/libraries/ldclient/ldclient-provider-rdf/src/main/java/org/apache/marmotta/ldclient/provider/rdf/AbstractRDFProvider.java
+++ b/libraries/ldclient/ldclient-provider-rdf/src/main/java/org/apache/marmotta/ldclient/provider/rdf/AbstractRDFProvider.java
@@ -71,12 +71,7 @@ public abstract class AbstractRDFProvider extends AbstractHttpProvider {
         RDFFormat format = RDFParserRegistry.getInstance().getFileFormatForMIMEType(contentType, RDFFormat.RDFXML);
 
         try {
-            ModelCommons.add(triples, in, resourceUri, format, new Predicate<Statement>() {
-                @Override
-                public boolean test(Statement param) {
-                    return StringUtils.equals(param.getSubject().stringValue(), resourceUri);
-                }
-            });
+            ModelCommons.add(triples, in, resourceUri, format);
 
             return Collections.emptyList();
         } catch (RDFParseException e) {

--- a/libraries/ldpath/ldpath-api/src/main/java/org/apache/marmotta/ldpath/api/backend/RDFBackend.java
+++ b/libraries/ldpath/ldpath-api/src/main/java/org/apache/marmotta/ldpath/api/backend/RDFBackend.java
@@ -64,4 +64,5 @@ public interface RDFBackend<Node> extends NodeBackend<Node> {
      */
     public Collection<Node> listSubjects(Node property, Node object);
 
+    public Collection<Node> getSubjectWithinResource(Node resourceUri, Node subject);
 }

--- a/libraries/ldpath/ldpath-backend-jena/src/main/java/org/apache/marmotta/ldpath/backend/jena/GenericJenaBackend.java
+++ b/libraries/ldpath/ldpath-backend-jena/src/main/java/org/apache/marmotta/ldpath/backend/jena/GenericJenaBackend.java
@@ -33,6 +33,7 @@ import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -467,5 +468,10 @@ public class GenericJenaBackend implements RDFBackend<RDFNode> {
             } catch(ClassCastException ex) {
             throw new IllegalArgumentException("property was no valid resource in the Jena model",ex);
         }
+    }
+
+    @Override
+    public Collection<RDFNode> getSubjectWithinResource(RDFNode resourceUri, RDFNode subject) {
+        return Collections.singleton(subject);
     }
 }

--- a/libraries/ldpath/ldpath-backend-linkeddata/src/main/java/org/apache/marmotta/ldpath/backend/linkeddata/LDCacheBackend.java
+++ b/libraries/ldpath/ldpath-backend-linkeddata/src/main/java/org/apache/marmotta/ldpath/backend/linkeddata/LDCacheBackend.java
@@ -25,6 +25,7 @@ import org.apache.marmotta.ldpath.api.backend.RDFBackend;
 import org.openrdf.model.BNode;
 import org.openrdf.model.Literal;
 import org.openrdf.model.Model;
+import org.openrdf.model.Resource;
 import org.openrdf.model.Value;
 import org.openrdf.model.impl.LiteralImpl;
 import org.openrdf.model.impl.URIImpl;
@@ -327,9 +328,9 @@ public class LDCacheBackend implements RDFBackend<Value> {
             final Model statements = ldcache.get(s);
 
             final Model filter;
-            if (s.getNamespace().equals(LDCache.SKOLEMIZED_NAMESPACE) && statements.getNamespace(LDCache.SMUGGLED_ORIGINAL_RESOURCE_ID) != null) {
-                final org.openrdf.model.URI realSubject = ValueFactoryImpl.getInstance().createURI(statements.getNamespace(LDCache.SMUGGLED_ORIGINAL_RESOURCE_ID).getName());
-                filter = statements.filter(realSubject, p, null);
+            if (s.getNamespace().equals(LDCache.SKOLEMIZED_NAMESPACE)) {
+                final Resource resource = statements.filter(s, OWL.SAMEAS, null).objectResource();
+                filter = statements.filter(resource, p, null);
             } else {
                 filter = statements.filter(s, p, null);
             }
@@ -358,8 +359,8 @@ public class LDCacheBackend implements RDFBackend<Value> {
     public Collection<Value> getSubjectWithinResource(Value resourceUri, Value subject) {
         log.info("retrieving subject {} within resource {}", subject, resourceUri);
 
-        if(subject instanceof org.openrdf.model.URI && resourceUri instanceof org.openrdf.model.URI) {
-            org.openrdf.model.URI s = (org.openrdf.model.URI) subject;
+        if((subject instanceof org.openrdf.model.Resource) && resourceUri instanceof org.openrdf.model.URI) {
+            org.openrdf.model.Resource s = (org.openrdf.model.Resource) subject;
             org.openrdf.model.URI r = (org.openrdf.model.URI) resourceUri;
 
             return Collections.singleton((Value) ldcache.createSubjectForResourceWithinRequest(r, s));

--- a/libraries/ldpath/ldpath-backend-linkeddata/src/main/java/org/apache/marmotta/ldpath/backend/linkeddata/LDCacheBackend.java
+++ b/libraries/ldpath/ldpath-backend-linkeddata/src/main/java/org/apache/marmotta/ldpath/backend/linkeddata/LDCacheBackend.java
@@ -28,6 +28,7 @@ import org.openrdf.model.Model;
 import org.openrdf.model.Value;
 import org.openrdf.model.impl.LiteralImpl;
 import org.openrdf.model.impl.URIImpl;
+import org.openrdf.model.impl.ValueFactoryImpl;
 import org.openrdf.model.vocabulary.OWL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -325,12 +326,10 @@ public class LDCacheBackend implements RDFBackend<Value> {
 
             final Model statements = ldcache.get(s);
 
-            final org.openrdf.model.URI sameAs = (org.openrdf.model.URI) OWL.SAMEAS;
             final Model filter;
-            if (s.getNamespace().equals(LDCache.SKOLEMIZED_NAMESPACE) && statements.contains(s, sameAs, null)) {
-                s = statements.filter(s, sameAs, null).objectURI();
-                filter = statements.filter(s, p, null);
-
+            if (s.getNamespace().equals(LDCache.SKOLEMIZED_NAMESPACE) && statements.getNamespace(LDCache.SMUGGLED_ORIGINAL_RESOURCE_ID) != null) {
+                final org.openrdf.model.URI realSubject = ValueFactoryImpl.getInstance().createURI(statements.getNamespace(LDCache.SMUGGLED_ORIGINAL_RESOURCE_ID).getName());
+                filter = statements.filter(realSubject, p, null);
             } else {
                 filter = statements.filter(s, p, null);
             }

--- a/libraries/ldpath/ldpath-backend-linkeddata/src/test/java/org/apache/marmotta/ldpath/backend/linkeddata/test/LDCacheBackendTest.java
+++ b/libraries/ldpath/ldpath-backend-linkeddata/src/test/java/org/apache/marmotta/ldpath/backend/linkeddata/test/LDCacheBackendTest.java
@@ -51,7 +51,8 @@ public class LDCacheBackendTest extends BaseLDCacheTest {
         pathTests.put(GEONAMES, ImmutableMap.of("<http://www.geonames.org/ontology#name>", "Embrun"));
         pathTests.put(MARMOTTA, ImmutableMap.of("<http://usefulinc.com/ns/doap#name>", "Apache Marmotta"));
         pathTests.put(WIKIER, ImmutableMap.of("<http://xmlns.com/foaf/0.1/name>[@es]", "Sergio Fernández",
-                                              "(foaf:weblog within .) / <http://purl.org/dc/terms/title>[@en]", "Wikier.org blog"
+                                              "(foaf:weblog within .) / <http://purl.org/dc/terms/title>[@en]", "Wikier.org blog",
+                                              "(* within <http://xmlns.com/wot/0.1/hasKey>) / <http://xmlns.com/wot/0.1/fingerprint>[@en]", "48B33394FA7F07D2A37FF197F21D21375531369F"
                                               ));
 
     }

--- a/libraries/ldpath/ldpath-backend-linkeddata/src/test/java/org/apache/marmotta/ldpath/backend/linkeddata/test/LDCacheBackendTest.java
+++ b/libraries/ldpath/ldpath-backend-linkeddata/src/test/java/org/apache/marmotta/ldpath/backend/linkeddata/test/LDCacheBackendTest.java
@@ -18,6 +18,8 @@
 package org.apache.marmotta.ldpath.backend.linkeddata.test;
 
 import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import org.apache.marmotta.commons.sesame.model.ValueCommons;
 import org.apache.marmotta.ldcache.api.LDCachingBackend;
 import org.apache.marmotta.ldcache.backend.infinispan.LDCachingInfinispanBackend;
@@ -33,6 +35,7 @@ import org.openrdf.model.impl.URIImpl;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -42,20 +45,15 @@ import java.util.Map;
  */
 public class LDCacheBackendTest extends BaseLDCacheTest {
 
-    protected static Map<String,String> pathExpressions = new HashMap<>();
-    protected static Map<String,String> pathResults     = new HashMap<>();
+    protected static Map<String,Map<String, String>> pathTests = new HashMap<>();
     static {
-        pathExpressions.put(DBPEDIA, "rdfs:label[@en]");
-        pathResults.put(DBPEDIA, "Berlin");
+        pathTests.put(DBPEDIA, ImmutableMap.of("rdfs:label[@en]", "Berlin"));
+        pathTests.put(GEONAMES, ImmutableMap.of("<http://www.geonames.org/ontology#name>", "Embrun"));
+        pathTests.put(MARMOTTA, ImmutableMap.of("<http://usefulinc.com/ns/doap#name>", "Apache Marmotta"));
+        pathTests.put(WIKIER, ImmutableMap.of("<http://xmlns.com/foaf/0.1/name>[@es]", "Sergio Fernández",
+                                              "(foaf:weblog within .) / <http://purl.org/dc/terms/title>[@en]", "Wikier.org blog"
+                                              ));
 
-        pathExpressions.put(GEONAMES, "<http://www.geonames.org/ontology#name>");
-        pathResults.put(GEONAMES, "Embrun");
-
-        pathExpressions.put(MARMOTTA, "<http://usefulinc.com/ns/doap#name>");
-        pathResults.put(MARMOTTA, "Apache Marmotta");
-
-        pathExpressions.put(WIKIER, "<http://xmlns.com/foaf/0.1/name>[@es]");
-        pathResults.put(WIKIER, "Sergio Fernández");
     }
 
         /**
@@ -81,12 +79,18 @@ public class LDCacheBackendTest extends BaseLDCacheTest {
     protected void testResource(String uri, String sparqlFile) throws Exception {
         super.testResource(uri, sparqlFile);
 
-        if(pathExpressions.containsKey(uri)) {
+        if(pathTests.containsKey(uri)) {
             LDPath<Value> ldpath = new LDPath<Value>(createLDPathBackend());
 
-            Collection<String> results = Collections2.transform(ldpath.pathQuery(new URIImpl(uri), pathExpressions.get(uri), Collections.EMPTY_MAP), ValueCommons.stringValue());
+            final Map<String, String> test = pathTests.get(uri);
 
-            Assert.assertThat(results, Matchers.hasItem(pathResults.get(uri)));
+            for (Map.Entry<String, String> t : test.entrySet()) {
+                Collection<String> results = Collections2.transform(ldpath.pathQuery(new URIImpl(uri), t.getKey(), Collections.EMPTY_MAP), ValueCommons.stringValue());
+                Assert.assertThat(results, Matchers.hasItem(t.getValue()));
+
+            }
+
+
 
         }
     }

--- a/libraries/ldpath/ldpath-backend-sesame/src/main/java/org/apache/marmotta/ldpath/backend/sesame/SesameConnectionBackend.java
+++ b/libraries/ldpath/ldpath-backend-sesame/src/main/java/org/apache/marmotta/ldpath/backend/sesame/SesameConnectionBackend.java
@@ -19,6 +19,7 @@ package org.apache.marmotta.ldpath.backend.sesame;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Locale;
 
 import org.openrdf.model.Literal;
@@ -92,6 +93,11 @@ public class SesameConnectionBackend extends AbstractSesameBackend {
                     "Property needs to be a URI node (property type: %s)",
                     isURI(property)?"URI":isBlank(property)?"bNode":"literal"),e);
         }
+    }
+
+    @Override
+    public Collection<Value> getSubjectWithinResource(Value resourceUri, Value subject) {
+        return Collections.singleton(subject);
     }
 
     /**

--- a/libraries/ldpath/ldpath-backend-sesame/src/main/java/org/apache/marmotta/ldpath/backend/sesame/SesameRepositoryBackend.java
+++ b/libraries/ldpath/ldpath-backend-sesame/src/main/java/org/apache/marmotta/ldpath/backend/sesame/SesameRepositoryBackend.java
@@ -19,6 +19,7 @@ package org.apache.marmotta.ldpath.backend.sesame;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Locale;
 
 import org.openrdf.model.Literal;
@@ -181,4 +182,10 @@ public class SesameRepositoryBackend extends AbstractSesameBackend {
         }
 
     }
+
+    @Override
+    public Collection<Value> getSubjectWithinResource(Value resourceUri, Value subject) {
+        return Collections.singleton(subject);
+    }
 }
+

--- a/libraries/ldpath/ldpath-core/src/main/java/org/apache/marmotta/ldpath/model/selectors/WithinPathSelector.java
+++ b/libraries/ldpath/ldpath-core/src/main/java/org/apache/marmotta/ldpath/model/selectors/WithinPathSelector.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.marmotta.ldpath.model.selectors;
+
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.marmotta.ldpath.api.backend.NodeBackend;
+import org.apache.marmotta.ldpath.api.backend.RDFBackend;
+import org.apache.marmotta.ldpath.api.selectors.NodeSelector;
+
+/**
+ * Retrieve a placeholder subject for a graph embedded within another resource
+ * <p/>
+ * Author: Chris Beer <cabeer@stanford.edu>
+ */
+public class WithinPathSelector<Node> implements NodeSelector<Node> {
+
+    private NodeSelector<Node> left;
+    private NodeSelector<Node> right;
+
+    public WithinPathSelector(NodeSelector left, NodeSelector<Node> right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    /**
+     * Apply the selector to the context node passed as argument and return the collection
+     * of selected nodes in appropriate order.
+     *
+     * @param context     the node where to start the selection
+     * @param path        the path leading to and including the context node in the current evaluation of LDPath; may be null,
+     *                    in which case path tracking is disabled
+     * @param resultPaths a map where each of the result nodes maps to a path leading to the result node in the LDPath evaluation;
+     *                    if null, path tracking is disabled and the path argument is ignored
+     * @return the collection of selected nodes
+     */
+    @Override
+    public Collection<Node> select(RDFBackend<Node> rdfBackend, Node context, List<Node> path, Map<Node, List<Node>> resultPaths) {
+        // a new map for storing the result path for the left selector
+        Map<Node,List<Node>> myResultPaths = null;
+        if(resultPaths != null && path != null) {
+            myResultPaths = new HashMap<Node, List<Node>>();
+        }
+
+        Collection<Node> nodesLeft = left.select(rdfBackend,context,path,myResultPaths);
+        Collection<Node> nodesRight = right.select(rdfBackend,context,path,myResultPaths);
+        final Set<Node> result = new HashSet<Node>();
+
+        for(Node n : nodesLeft) {
+            for(Node r : nodesRight) {
+
+                if(myResultPaths != null && myResultPaths.get(n) != null) {
+                    result.addAll(rdfBackend.getSubjectWithinResource(r, n));
+                } else {
+                    result.addAll(rdfBackend.getSubjectWithinResource(r, n));
+                }
+            }
+        }
+
+        return result;
+    }
+
+
+    @Override
+    public String getPathExpression(NodeBackend<Node> backend) {
+        return String.format("%s within %s", left.getPathExpression(backend), right.getPathExpression(backend));
+    }
+
+    /**
+     * Return a name for this selector to be used as the name for the whole path if not explicitly
+     * specified. In complex selector expressions, this is typically delegated to the first
+     * occurrence of an atomic selector.
+     */
+    @Override
+    public String getName(NodeBackend<Node> nodeRDFBackend) {
+        return left.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        @SuppressWarnings("rawtypes")
+        WithinPathSelector that = (WithinPathSelector) o;
+
+        if (left != null ? !left.equals(that.left) : that.left != null) return false;
+        if (right != null ? !right.equals(that.right) : that.right != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = left != null ? left.hashCode() : 0;
+        result = 31 * result + (right != null ? right.hashCode() : 0);
+        return result;
+    }
+}

--- a/libraries/ldpath/ldpath-core/src/main/java/org/apache/marmotta/ldpath/model/selectors/WithinPathSelector.java
+++ b/libraries/ldpath/ldpath-core/src/main/java/org/apache/marmotta/ldpath/model/selectors/WithinPathSelector.java
@@ -68,13 +68,20 @@ public class WithinPathSelector<Node> implements NodeSelector<Node> {
         Collection<Node> nodesRight = right.select(rdfBackend,context,path,myResultPaths);
         final Set<Node> result = new HashSet<Node>();
 
-        for(Node n : nodesLeft) {
+        if (left instanceof WildcardSelector) {
             for(Node r : nodesRight) {
+                result.addAll(rdfBackend.getSubjectWithinResource(context, r));
+            }
+        } else {
 
-                if(myResultPaths != null && myResultPaths.get(n) != null) {
-                    result.addAll(rdfBackend.getSubjectWithinResource(r, n));
-                } else {
-                    result.addAll(rdfBackend.getSubjectWithinResource(r, n));
+            for(Node n : nodesLeft) {
+                for(Node r : nodesRight) {
+
+                    if(myResultPaths != null && myResultPaths.get(n) != null) {
+                        result.addAll(rdfBackend.getSubjectWithinResource(r, n));
+                    } else {
+                        result.addAll(rdfBackend.getSubjectWithinResource(r, n));
+                    }
                 }
             }
         }

--- a/libraries/ldpath/ldpath-core/src/main/javacc/org/apache/marmotta/ldpath/parser/ldpath.jj
+++ b/libraries/ldpath/ldpath-core/src/main/javacc/org/apache/marmotta/ldpath/parser/ldpath.jj
@@ -418,6 +418,7 @@ TOKEN : /* OPERATORS */
 	< IS_A: "is-a" > |
     < FUNC: "fn:" >  |
   	< TYPE: "^^" >   |
+  	< WITHIN: "within" >   |
   	< LANG: "@" >
 }
 
@@ -660,8 +661,10 @@ NodeSelector CompoundSelector() :
         result = IntersectionSelector() |
 
         /* Path Selector */
-        result = PathSelector()
+        result = PathSelector()  |
 
+        /* Within Path Selector */
+        result = WithinPathSelector()
 
     )
     {
@@ -742,6 +745,20 @@ NodeSelector AtomicSelector() :
     }
 }
 
+NodeSelector PropertyOrSelfSelector() :
+{
+    NodeSelector result = null;
+}
+{
+    (
+        result = SelfSelector() |
+        result = PropertySelector()
+    )
+    {
+        return result;
+    }
+}
+
 NodeSelector SelfSelector() :
 {
 }
@@ -790,6 +807,20 @@ PathSelector PathSelector() :
     left = AtomicOrTestingSelector() <P_SEP> right = AtomicOrTestingOrPathSelector()
     {
         result = new PathSelector(left,right);
+        return result;
+    }
+}
+
+WithinPathSelector WithinPathSelector() :
+{
+    WithinPathSelector result = null;
+    NodeSelector left   = null;
+    NodeSelector right  = null;
+}
+{
+    left = PropertyOrSelfSelector() <WITHIN> right = AtomicOrTestingOrPathSelector()
+    {
+        result = new WithinPathSelector(left,right);
         return result;
     }
 }

--- a/libraries/ldpath/ldpath-core/src/main/javacc/org/apache/marmotta/ldpath/parser/ldpath.jj
+++ b/libraries/ldpath/ldpath-core/src/main/javacc/org/apache/marmotta/ldpath/parser/ldpath.jj
@@ -818,7 +818,7 @@ WithinPathSelector WithinPathSelector() :
     NodeSelector right  = null;
 }
 {
-    left = PropertyOrSelfSelector() <WITHIN> right = AtomicOrTestingOrPathSelector()
+    left = AtomicSelector() <WITHIN> right = AtomicOrTestingOrPathSelector()
     {
         result = new WithinPathSelector(left,right);
         return result;

--- a/libraries/ldpath/ldpath-core/src/test/java/org/apache/marmotta/ldpath/model/selectors/WithinPathSelectorTest.java
+++ b/libraries/ldpath/ldpath-core/src/test/java/org/apache/marmotta/ldpath/model/selectors/WithinPathSelectorTest.java
@@ -1,0 +1,53 @@
+package org.apache.marmotta.ldpath.model.selectors;
+
+import org.apache.marmotta.ldpath.model.fields.FieldMapping;
+import org.apache.marmotta.ldpath.parser.LdPathParser;
+import org.apache.marmotta.ldpath.parser.ParseException;
+import org.apache.marmotta.ldpath.test.AbstractTestBase;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.openrdf.model.URI;
+import org.openrdf.model.Value;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.rio.RDFFormat;
+import org.openrdf.rio.RDFParseException;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static org.junit.Assert.assertThat;
+
+public class WithinPathSelectorTest extends AbstractTestBase {
+
+    @Before
+    public void loadData() throws RepositoryException, RDFParseException, IOException {
+        loadData("/ldpath/test-data.n3", RDFFormat.N3);
+    }
+
+
+    @Test
+    public void testPropertyWithinPathSelector() throws ParseException {
+
+        LdPathParser<Value> parser = createParserFromString("(foo:seeAlso within .) / foo:title :: xsd:string; ");
+        final URI context = repository.getValueFactory().createURI("http://www.example.com/1");
+
+        final FieldMapping<Object, Value> field = parser.parseRule(NSS);
+        final Collection<Object> result = field.getValues(backend, context);
+
+        assertThat(result, CoreMatchers.hasItem("Title for seeAlso'd object"));
+    }
+
+
+    @Test
+    public void testSelfWithinPathSelector() throws ParseException {
+
+        LdPathParser<Value> parser = createParserFromString("(. within foo:seeAlso) / foo:title :: xsd:string; ");
+        final URI context = repository.getValueFactory().createURI("http://www.example.com/1");
+
+        final FieldMapping<Object, Value> field = parser.parseRule(NSS);
+        final Collection<Object> result = field.getValues(backend, context);
+
+        assertThat(result, CoreMatchers.hasItem("One"));
+    }
+}

--- a/libraries/ldpath/ldpath-core/src/test/java/org/apache/marmotta/ldpath/model/selectors/WithinPathSelectorTest.java
+++ b/libraries/ldpath/ldpath-core/src/test/java/org/apache/marmotta/ldpath/model/selectors/WithinPathSelectorTest.java
@@ -38,7 +38,6 @@ public class WithinPathSelectorTest extends AbstractTestBase {
         assertThat(result, CoreMatchers.hasItem("Title for seeAlso'd object"));
     }
 
-
     @Test
     public void testSelfWithinPathSelector() throws ParseException {
 
@@ -49,5 +48,17 @@ public class WithinPathSelectorTest extends AbstractTestBase {
         final Collection<Object> result = field.getValues(backend, context);
 
         assertThat(result, CoreMatchers.hasItem("One"));
+    }
+
+    @Test
+    public void testWildcardWithinPathSelector() throws ParseException {
+
+        LdPathParser<Value> parser = createParserFromString("(* within foo:seeAlso) / foo:title :: xsd:string; ");
+        final URI context = repository.getValueFactory().createURI("http://www.example.com/1");
+
+        final FieldMapping<Object, Value> field = parser.parseRule(NSS);
+        final Collection<Object> result = field.getValues(backend, context);
+
+        assertThat(result, CoreMatchers.hasItem("Title for seeAlso'd object"));
     }
 }

--- a/libraries/ldpath/ldpath-core/src/test/java/org/apache/marmotta/ldpath/parser/SelectorsTest.java
+++ b/libraries/ldpath/ldpath-core/src/test/java/org/apache/marmotta/ldpath/parser/SelectorsTest.java
@@ -51,6 +51,7 @@ public class SelectorsTest {
                 {"(<http://www.example.com/>)*", "RecursivePath"},
                 {"(<http://www.example.com/>)+", "RecursivePath"},
                 {"^<http://www.example.com/>", "ReverseProperty"},
+                {". within <http://www.example.com/>", "WithinPath"},
                 {"fn:count(\"foo\")", "Function"},
                 // Not implemented yet: {"^*", "ReverseProperty"},
                 {".", "Self"},

--- a/libraries/ldpath/ldpath-core/src/test/resources/ldpath/test-data.n3
+++ b/libraries/ldpath/ldpath-core/src/test/resources/ldpath/test-data.n3
@@ -25,13 +25,17 @@ ex:1 a ex:Item;
 	foo:title	"One";
 	foo:subtitle	"SubOne";
 	foo:i	"1", "2", "3";
-	foo:j	"2".
+	foo:j	"2";
+	foo:seeAlso ex:moreDataAbout1 .
 	
 ex:2 a ex:Item;
 	foo:title	"Two";
 	foo:subtitle	"SubTwo";
 	foo:i	"99";
 	foo:j	"99".
+
+ex:moreDataAbout1 a ex:Item;
+    foo:title "Title for seeAlso'd object" .
 
 ex:Compare a ex:Test;
 	ex:hasItem ex:Eq, ex:Lt, ex:Gt.

--- a/libraries/ldpath/ldpath-core/src/test/resources/parse/program.ldpath
+++ b/libraries/ldpath/ldpath-core/src/test/resources/parse/program.ldpath
@@ -28,6 +28,7 @@ type_test = foo:p2[^^test:int] :: test:type ;
 int_s = (foo:go)* :: test:type ;
 int_p = (foo:go)+ :: test:type ;
 group = (test:p1 / test:p2) :: test:type ;
+within_test = . within foo:seeAlso / test:foo :: test:type ;
 
 inverse = ^test:incoming :: test:type ;
 


### PR DESCRIPTION
Remote RDF resources sometimes contain additional RDF resources besides
the request URI. When these inlined resources are requested (using x
within y), mint a temporary identifier for the resource in the ldcache
and allow it to be used by downstream selectors as if it were a
full-fledged web resource.

https://issues.apache.org/jira/browse/MARMOTTA-500
