### PR TITLE
Add an LDPath function to retrieve a back-end defined response header

### DIFF
--- a/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/api/LDCachingService.java
+++ b/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/api/LDCachingService.java
@@ -16,6 +16,7 @@
  */
 package org.apache.marmotta.ldcache.api;
 
+import com.google.common.collect.Multimap;
 import org.openrdf.model.Model;
 import org.openrdf.model.URI;
 
@@ -80,6 +81,13 @@ public interface LDCachingService {
      */
     public void shutdown();
 
+    /**
+     * Get the headers from the response
+     * @param resource the resource to retrieve headers for
+     * @param options  options for refreshing
+     * @return a Multimap of the header name and the header values
+     */
+    Multimap<String, String> headers(URI resource, RefreshOpts... options);
 
 
     public enum RefreshOpts {

--- a/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/model/CacheEntry.java
+++ b/libraries/ldcache/ldcache-api/src/main/java/org/apache/marmotta/ldcache/model/CacheEntry.java
@@ -17,6 +17,7 @@
  */
 package org.apache.marmotta.ldcache.model;
 
+import com.google.common.collect.Multimap;
 import org.apache.marmotta.commons.util.DateUtils;
 import org.openrdf.model.Model;
 import org.openrdf.model.URI;
@@ -60,6 +61,7 @@ public class CacheEntry implements Serializable {
      * The number of triples that have been retrieved in the last cache refresh.
      */
     private Integer tripleCount;
+    private Multimap<String, String> headers;
 
 
     public CacheEntry() {
@@ -156,4 +158,9 @@ public class CacheEntry implements Serializable {
         return String.format("CacheEntry(resource=%s,triples=%d,expiry=%s)", getResource().stringValue(), getTripleCount(), DateUtils.ISO8601FORMAT.format(getExpiryDate()));
     }
 
+    public void setHeaders(Multimap<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public Multimap<String,String> getHeaders() { return headers; }
 }

--- a/libraries/ldcache/ldcache-core/src/main/java/org/apache/marmotta/ldcache/services/LDCache.java
+++ b/libraries/ldcache/ldcache-core/src/main/java/org/apache/marmotta/ldcache/services/LDCache.java
@@ -17,6 +17,7 @@
 
 package org.apache.marmotta.ldcache.services;
 
+import com.google.common.collect.Multimap;
 import org.apache.marmotta.commons.locking.ObjectLocks;
 import org.apache.marmotta.ldcache.api.LDCachingBackend;
 import org.apache.marmotta.ldcache.api.LDCachingService;
@@ -28,6 +29,7 @@ import org.apache.marmotta.ldclient.model.ClientResponse;
 import org.apache.marmotta.ldclient.services.ldclient.LDClient;
 import org.openrdf.model.Model;
 import org.openrdf.model.URI;
+import org.openrdf.model.Value;
 import org.openrdf.model.impl.TreeModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -124,6 +126,7 @@ public class LDCache implements LDCachingService {
                     newEntry.setResource(resource);
                     newEntry.setExpiryDate(response.getExpires());
                     newEntry.setLastRetrieved(new Date());
+                    newEntry.setHeaders(response.getHeaders());
                     if(entry != null) {
                         newEntry.setUpdateCount(entry.getUpdateCount()+1);
                     } else {
@@ -221,6 +224,18 @@ public class LDCache implements LDCachingService {
     @Override
     public void shutdown() {
         backend.shutdown();
+    }
+
+    /**
+     * Get the headers from the response
+     * @param resource the resource to retrieve headers for
+     * @param options  options for refreshing
+     * @return a Multimap of the header name and the header values
+     */
+    @Override
+    public Multimap<String, String> headers(URI resource, RefreshOpts... options) {
+        refresh(resource, options);
+        return backend.getEntry(resource).getHeaders();
     }
 
 

--- a/libraries/ldclient/ldclient-api/pom.xml
+++ b/libraries/ldclient/ldclient-api/pom.xml
@@ -97,5 +97,11 @@
             <artifactId>httpclient</artifactId>
         </dependency>
 
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>16.0</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/libraries/ldclient/ldclient-api/src/main/java/org/apache/marmotta/ldclient/model/ClientResponse.java
+++ b/libraries/ldclient/ldclient-api/src/main/java/org/apache/marmotta/ldclient/model/ClientResponse.java
@@ -17,6 +17,8 @@
  */
 package org.apache.marmotta.ldclient.model;
 
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.marmotta.commons.sesame.model.ModelCommons;
 import org.openrdf.model.Model;
@@ -47,22 +49,30 @@ public class ClientResponse {
 
     private Date expires;
 
+    private Multimap<String, String> headers;
+
     @Deprecated
     public ClientResponse(int httpStatus, Repository triples) {
         this.expires = DateUtils.addDays(new Date(), DEFAULT_EXPIRATION_IN_DAYS);
         this.httpStatus = httpStatus;
 
         try {
-        this.data = ModelCommons.asModel(triples);
+            this.data = ModelCommons.asModel(triples);
         } catch (RepositoryException e) {
             this.data = new TreeModel();
         }
+        this.headers = ImmutableMultimap.of();
     }
 
     public ClientResponse(int httpStatus, Model triples) {
+        this(httpStatus, triples, new ImmutableMultimap.Builder<String,String>().build());
+    }
+
+    public ClientResponse(int httpStatus, Model triples, Multimap<String, String> headers) {
         this.data = triples;
         this.expires = DateUtils.addDays(new Date(), DEFAULT_EXPIRATION_IN_DAYS);
         this.httpStatus = httpStatus;
+        this.headers = headers;
     }
 
 
@@ -93,5 +103,13 @@ public class ClientResponse {
 
     public void setHttpStatus(int httpStatus) {
         this.httpStatus = httpStatus;
+    }
+
+    public void setHeaders(Multimap<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public Multimap<String, String> getHeaders() {
+        return headers;
     }
 }

--- a/libraries/ldclient/ldclient-provider-rdf/src/test/java/org/apache/marmotta/ldclient/test/rdf/TestLinkedDataProvider.java
+++ b/libraries/ldclient/ldclient-provider-rdf/src/test/java/org/apache/marmotta/ldclient/test/rdf/TestLinkedDataProvider.java
@@ -21,8 +21,11 @@ import org.apache.marmotta.ldclient.exception.DataRetrievalException;
 import org.apache.marmotta.ldclient.model.ClientResponse;
 import org.apache.marmotta.ldclient.test.provider.ProviderTestBase;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test if the LinkedDataProvider is working properly.
@@ -109,6 +112,12 @@ public class TestLinkedDataProvider extends ProviderTestBase {
     public void testSSL() throws Exception {
         ClientResponse response = ldclient.retrieveResource(SSL);
         Assert.assertTrue(response.getData().size() == 0);
+    }
+
+    @Test
+    public void testHeaders() throws Exception {
+        ClientResponse response = ldclient.retrieveResource(WIKIER);
+        assertEquals(1, response.getHeaders().get("Date").size());
     }
 
 }

--- a/libraries/ldpath/ldpath-api/src/main/java/org/apache/marmotta/ldpath/api/backend/RDFBackend.java
+++ b/libraries/ldpath/ldpath-api/src/main/java/org/apache/marmotta/ldpath/api/backend/RDFBackend.java
@@ -64,4 +64,6 @@ public interface RDFBackend<Node> extends NodeBackend<Node> {
      */
     public Collection<Node> listSubjects(Node property, Node object);
 
+
+    public Collection<Node> getHeaders(Node context, Node property);
 }

--- a/libraries/ldpath/ldpath-backend-jena/src/main/java/org/apache/marmotta/ldpath/backend/jena/GenericJenaBackend.java
+++ b/libraries/ldpath/ldpath-backend-jena/src/main/java/org/apache/marmotta/ldpath/backend/jena/GenericJenaBackend.java
@@ -34,7 +34,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 
 import org.apache.marmotta.ldpath.api.backend.RDFBackend;
@@ -467,5 +469,11 @@ public class GenericJenaBackend implements RDFBackend<RDFNode> {
             } catch(ClassCastException ex) {
             throw new IllegalArgumentException("property was no valid resource in the Jena model",ex);
         }
+    }
+
+    @Override
+    public Collection<RDFNode> getHeaders(RDFNode context, RDFNode property) {
+        Set<RDFNode> result = new HashSet<RDFNode>();
+        return result;
     }
 }

--- a/libraries/ldpath/ldpath-backend-linkeddata/src/main/java/org/apache/marmotta/ldpath/backend/linkeddata/LDCacheBackend.java
+++ b/libraries/ldpath/ldpath-backend-linkeddata/src/main/java/org/apache/marmotta/ldpath/backend/linkeddata/LDCacheBackend.java
@@ -17,6 +17,9 @@
  */
 package org.apache.marmotta.ldpath.backend.linkeddata;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Multimap;
 import org.apache.marmotta.ldcache.api.LDCachingBackend;
 import org.apache.marmotta.ldcache.backend.infinispan.LDCachingInfinispanBackend;
 import org.apache.marmotta.ldcache.model.CacheConfiguration;
@@ -338,5 +341,27 @@ public class LDCacheBackend implements RDFBackend<Value> {
     @Override
     public Collection<Value> listSubjects(Value property, Value object) {
         throw new UnsupportedOperationException("reverse traversal not supported for Linked Data backend");
+    }
+
+    /**
+     * Retrieve the values of response header for a given resource
+     * @param subject the subject of the header to look for
+     * @param header the header to look for
+     * @return
+     */
+    @Override
+    public Collection<Value> getHeaders(Value subject, Value header) {
+        if(subject instanceof org.openrdf.model.URI) {
+            org.openrdf.model.URI s = (org.openrdf.model.URI) subject;
+            return Collections2.transform(ldcache.headers(s).get(stringValue(header)), new Function<String, Value>() {
+                @Override
+                public Value apply(String s) {
+                    return createLiteral(s);
+                }
+            });
+        } else {
+            Set<Value> result = new HashSet<Value>();
+            return result;
+        }
     }
 }

--- a/libraries/ldpath/ldpath-backend-sesame/src/main/java/org/apache/marmotta/ldpath/backend/sesame/AbstractSesameBackend.java
+++ b/libraries/ldpath/ldpath-backend-sesame/src/main/java/org/apache/marmotta/ldpath/backend/sesame/AbstractSesameBackend.java
@@ -137,4 +137,10 @@ public abstract class AbstractSesameBackend extends SesameValueBackend implement
     }
 
 
+    @Override
+    public Collection<Value> getHeaders(Value context, Value property) {
+        Set<Value> result = new HashSet<Value>();
+        return result;
+    }
+
 }

--- a/libraries/ldpath/ldpath-core/src/main/java/org/apache/marmotta/ldpath/model/functions/HeaderFunction.java
+++ b/libraries/ldpath/ldpath-core/src/main/java/org/apache/marmotta/ldpath/model/functions/HeaderFunction.java
@@ -1,0 +1,43 @@
+package org.apache.marmotta.ldpath.model.functions;
+
+import org.apache.marmotta.ldpath.api.backend.RDFBackend;
+import org.apache.marmotta.ldpath.api.functions.SelectorFunction;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+/**
+ * Extract the values of a response header from the RDFBackend
+ * @param <Node>
+ * Author: Chris Beer <cabeer@stanford.edu>
+ */
+public class HeaderFunction<Node> extends SelectorFunction<Node> {
+    @Override
+    protected String getLocalName() {
+        return "header";
+    }
+
+    @Override
+    public Collection<Node> apply(RDFBackend<Node> backend, Node context, @SuppressWarnings("unchecked") Collection<Node>... args) throws IllegalArgumentException {
+
+        LinkedList<Node> result = new LinkedList<Node>();
+
+        for (Collection<Node> arg : args) {
+            for (Node node : arg) {
+                result.addAll(backend.getHeaders(context, node));
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    public String getSignature() {
+        return "fn:header(header : String) : String";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Get a response header from the context resource";
+    }
+}

--- a/libraries/ldpath/ldpath-core/src/main/resources/META-INF/services/org.apache.marmotta.ldpath.api.functions.SelectorFunction
+++ b/libraries/ldpath/ldpath-core/src/main/resources/META-INF/services/org.apache.marmotta.ldpath.api.functions.SelectorFunction
@@ -3,3 +3,4 @@ org.apache.marmotta.ldpath.model.functions.FirstFunction
 org.apache.marmotta.ldpath.model.functions.LastFunction
 org.apache.marmotta.ldpath.model.functions.SortFunction
 org.apache.marmotta.ldpath.model.functions.CountFunction
+org.apache.marmotta.ldpath.model.functions.HeaderFunction

--- a/libraries/ldpath/ldpath-core/src/test/java/org/apache/marmotta/ldpath/model/functions/FunctionsTest.java
+++ b/libraries/ldpath/ldpath-core/src/test/java/org/apache/marmotta/ldpath/model/functions/FunctionsTest.java
@@ -149,6 +149,19 @@ public class FunctionsTest extends AbstractTestBase {
         final Collection<Value> resulti = seli.select(backend, start, null, null);
         assertEquals(1, resulti.size());
         assertThat(resulti, allOf(hasItem(ex1), not(hasItem(ex2))));
+    }
+
+    @Test
+    public void testHeader() throws ParseException {
+        final URI start = repository.getValueFactory().createURI("http://www.example.com/start");
+
+        final LdPathParser<Value> parser = createParserFromString("fn:header(\"Date\")");
+        final NodeSelector<Value> sel = parser.parseSelector(NSS);
+
+        final Collection<Value> result = sel.select(backend, start, null, null);
+        // the test provider will not provide any headers
+        assertEquals(0, result.size());
 
     }
+
 }


### PR DESCRIPTION
With the `fn:header` function, LDPath implementations can retrieve "headers" from the backend (which may be HTTP headers for some backends, but may be other metadata about the resource for others).

e.g. 

```
content_type = fn:header("Content-Type") :: xsd:string ;
```

Could result in:

```
content_type = {application/rdf+xml}
```

https://issues.apache.org/jira/browse/MARMOTTA-505