### PR TITLE
MARMOTTA-573: Modify jetty-web.xml configs for jetty 7.x+

### DIFF
--- a/build/archetypes/marmotta-archetype-webapp/src/main/resources/archetype-resources/src/main/webapp/META-INF/jetty-web.xml
+++ b/build/archetypes/marmotta-archetype-webapp/src/main/resources/archetype-resources/src/main/webapp/META-INF/jetty-web.xml
@@ -21,9 +21,10 @@
     limitations under the License.
 
 -->
-<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN"
+   "http://www.eclipse.org/jetty/configure.dtd">
 
-<Configure id="webAppCtx" class="org.mortbay.jetty.webapp.WebAppContext">
+<Configure id="webAppCtx" class="org.eclipse.jetty.webapp.WebAppContext">
    <Call class="org.jboss.weld.environment.jetty.WeldServletHandler" name="process">
       <Arg><Ref id="webAppCtx"/></Arg>
    </Call>

--- a/build/archetypes/marmotta-archetype-webapp/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/build/archetypes/marmotta-archetype-webapp/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/jetty-web.xml
@@ -18,20 +18,26 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN"
-   "http://jetty.mortbay.org/configure.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN"
+   "http://www.eclipse.org/jetty/configure.dtd">
 
-<Configure id="webAppCtx" class="org.mortbay.jetty.webapp.WebAppContext">
+<Configure id="webAppCtx" class="org.eclipse.jetty.webapp.WebAppContext">
+
+    <Set name="serverClasses">
+        <Array type="java.lang.String">
+            <Item>-org.eclipse.jetty.servlet.ServletContextHandler.Decorator</Item>
+        </Array>
+    </Set>
 
     <Array id="annotationConfig" type="java.lang.String">
-      <Item>org.mortbay.jetty.webapp.WebInfConfiguration</Item>
-      <Item>org.mortbay.jetty.plus.webapp.EnvConfiguration</Item>
-      <Item>org.mortbay.jetty.annotations.Configuration</Item> <!-- Enables annotation support -->
-      <Item>org.mortbay.jetty.webapp.JettyWebXmlConfiguration</Item>
-      <Item>org.mortbay.jetty.webapp.TagLibConfiguration</Item>
+      <Item>org.eclipse.jetty.webapp.WebInfConfiguration</Item>
+      <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
+      <Item>org.eclipse.jetty.annotations.AnnotationConfiguration</Item> <!-- Enables annotation support -->
+      <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
+      <Item>org.eclipse.jetty.webapp.TagLibConfiguration</Item>
     </Array>
 
-   <Call class="org.jboss.weld.environment.jetty.MortbayWeldServletHandler" name="process">
+   <Call class="org.jboss.weld.environment.jetty.EclipseWeldServletHandler" name="process">
       <Arg><Ref id="webAppCtx"/></Arg>
    </Call>
 </Configure>

--- a/launchers/marmotta-webapp/src/main/webapp/META-INF/jetty-web.xml
+++ b/launchers/marmotta-webapp/src/main/webapp/META-INF/jetty-web.xml
@@ -18,9 +18,10 @@
     limitations under the License.
 
 -->
-<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN" "http://jetty.mortbay.org/configure.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN"
+   "http://www.eclipse.org/jetty/configure.dtd">
 
-<Configure id="webAppCtx" class="org.mortbay.jetty.webapp.WebAppContext">
+<Configure id="webAppCtx" class="org.eclipse.jetty.webapp.WebAppContext">
    <Call class="org.jboss.weld.environment.jetty.WeldServletHandler" name="process">
       <Arg><Ref id="webAppCtx"/></Arg>
    </Call>

--- a/launchers/marmotta-webapp/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/launchers/marmotta-webapp/src/main/webapp/WEB-INF/jetty-web.xml
@@ -17,20 +17,26 @@
     limitations under the License.
 
 -->
-<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN"
-   "http://jetty.mortbay.org/configure.dtd">
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN"
+   "http://www.eclipse.org/jetty/configure.dtd">
 
-<Configure id="webAppCtx" class="org.mortbay.jetty.webapp.WebAppContext">
+<Configure id="webAppCtx" class="org.eclipse.jetty.webapp.WebAppContext">
+
+    <Set name="serverClasses">
+        <Array type="java.lang.String">
+            <Item>-org.eclipse.jetty.servlet.ServletContextHandler.Decorator</Item>
+        </Array>
+    </Set>
 
     <Array id="annotationConfig" type="java.lang.String">
-      <Item>org.mortbay.jetty.webapp.WebInfConfiguration</Item>
-      <Item>org.mortbay.jetty.plus.webapp.EnvConfiguration</Item>
-      <Item>org.mortbay.jetty.annotations.Configuration</Item> <!-- Enables annotation support -->
-      <Item>org.mortbay.jetty.webapp.JettyWebXmlConfiguration</Item>
-      <Item>org.mortbay.jetty.webapp.TagLibConfiguration</Item>
+      <Item>org.eclipse.jetty.webapp.WebInfConfiguration</Item>
+      <Item>org.eclipse.jetty.plus.webapp.EnvConfiguration</Item>
+      <Item>org.eclipse.jetty.annotations.AnnotationConfiguration</Item> <!-- Enables annotation support -->
+      <Item>org.eclipse.jetty.webapp.JettyWebXmlConfiguration</Item>
+      <Item>org.eclipse.jetty.webapp.TagLibConfiguration</Item>
     </Array>
 
-   <Call class="org.jboss.weld.environment.jetty.MortbayWeldServletHandler" name="process">
+   <Call class="org.jboss.weld.environment.jetty.EclipseWeldServletHandler" name="process">
       <Arg><Ref id="webAppCtx"/></Arg>
    </Call>
 </Configure>


### PR DESCRIPTION
The current jetty-web.xml configuration files refer to the old org.mortbay class names, which predates when Jetty moved to being an Eclipse project. Updating these configuration files would allow Marmotta to be deployed on more recent versions of Jetty.
