### PR TITLE
Allow multiple accept headers in SPARQL web service MARMOTTA-591

### DIFF
--- a/commons/marmotta-commons/src/main/java/org/apache/marmotta/commons/http/MarmottaHttpUtils.java
+++ b/commons/marmotta-commons/src/main/java/org/apache/marmotta/commons/http/MarmottaHttpUtils.java
@@ -64,6 +64,28 @@ public class MarmottaHttpUtils {
         return contentTypes;
     }
 
+    /**
+     * A utility method for parsing HTTP Content-Type and Accept header, taking into account different parameters that
+     * are typically passed. Recognized parameters:
+     * - charset: gives the charset of the content
+     * - q: gives the precedence of the content
+     * The result is an ordered list of content types in order of the computed preference in the header value passed as
+     * string argument.
+     * <p/>
+     * Author: Kai Schlegel
+     */
+    public static List<ContentType> parseAcceptHeaders(List<String> headers) {
+        List<ContentType> result = new ArrayList<>();
+
+        for(String header : headers) {
+            result.addAll(parseAcceptHeader(header));
+        }
+
+        Collections.sort(result);
+
+        return result;
+    }
+
 
     public static List<ContentType> parseStringList(Collection<String> types) {
         List<ContentType> contentTypes = new ArrayList<ContentType>(types.size());

--- a/platform/marmotta-sparql/src/test/java/org/apache/marmotta/platform/sparql/webservices/SparqlWebServiceTest.java
+++ b/platform/marmotta-sparql/src/test/java/org/apache/marmotta/platform/sparql/webservices/SparqlWebServiceTest.java
@@ -190,4 +190,18 @@ public class SparqlWebServiceTest {
                 get("/sparql/select");
     }
 
+    @Test
+    public void testMultipleAcceptHeaders() throws IOException, InterruptedException {
+        expect().
+                log().ifError().
+                statusCode(200).
+                contentType("application/rdf+json").
+                given().
+                header("Accept", "application/na").
+                header("Accept", "application/rdf+json; q=1.0").
+                param("query", "DESCRIBE <http://www.wikier.org/foaf#wikier>").
+                when().
+                get("/sparql/select");
+    }
+
 }


### PR DESCRIPTION
The current implementation only supports single HTTP accept headers with comma separated values. RFC 2616 also allows multiple HTTP headers (e.g. ACCEPT).