### PR TITLE
MARMOTTA-620 Reduce locking to improve concurrent write performance

### DIFF
--- a/libraries/kiwi/kiwi-triplestore/src/main/java/org/apache/marmotta/kiwi/sail/KiWiValueFactory.java
+++ b/libraries/kiwi/kiwi-triplestore/src/main/java/org/apache/marmotta/kiwi/sail/KiWiValueFactory.java
@@ -565,6 +565,8 @@ public class KiWiValueFactory implements ValueFactory {
 
             KiWiTriple result = new KiWiTriple(ksubject,kpredicate,kobject,kcontext);
 
+            boolean needsDBLookup = false;
+
             synchronized (registry) {
                 long tripleId = registry.lookupKey(cacheKey);
 
@@ -575,13 +577,29 @@ public class KiWiValueFactory implements ValueFactory {
                     registry.registerKey(cacheKey, connection.getTransactionId(), result.getId());
                 } else {
                     // not found in registry, try loading from database
-                    result.setId(connection.getTripleId(ksubject,kpredicate,kobject,kcontext));
+                    needsDBLookup = true;
                 }
+            }
 
-                // triple has no id from registry or database, so we create one and flag it for reasoning
-                if(result.getId() < 0) {
-                    result.setId(connection.getNextSequence());
-                    result.setNewTriple(true);
+            if(needsDBLookup) {
+                result.setId(connection.getTripleId(ksubject,kpredicate,kobject,kcontext));
+            }
+
+            // triple has no id from registry or database, so we create one and flag it for reasoning
+            if(result.getId() < 0) {
+                synchronized (registry) {
+                    // It's possible a concurrent thread might have created this
+                    // triple while we were blocked.  Check the registry again.
+                    long tripleId = registry.lookupKey(cacheKey);
+
+                    if(tripleId >= 0) {
+                        // A concurrent thread got in first.  Take the one it created.
+                        result.setId(tripleId);
+                    } else {
+                        // Create the new triple
+                        result.setId(connection.getNextSequence());
+                        result.setNewTriple(true);
+                    }
 
                     registry.registerKey(cacheKey, connection.getTransactionId(), result.getId());
                 }


### PR DESCRIPTION
Holding a shared lock while calling `connection.getTripleId()` makes
throughput quite sensitive to small variations in database latency.
Drop the lock prior to running this query, and only take it again when
necessary.