### PR TITLE
MARMOTTA-628: Arithmetic operation in SPARQL use wrong operator precedence

### DIFF
--- a/libraries/kiwi/kiwi-sparql/src/main/java/org/apache/marmotta/kiwi/sparql/builder/eval/ValueExpressionEvaluator.java
+++ b/libraries/kiwi/kiwi-sparql/src/main/java/org/apache/marmotta/kiwi/sparql/builder/eval/ValueExpressionEvaluator.java
@@ -500,9 +500,13 @@ public class ValueExpressionEvaluator extends QueryModelVisitorBase<RuntimeExcep
             }
 
             optypes.push(ot);
+	    builder.append("(");
             expr.getLeftArg().visit(this);
+	    builder.append(")");
             builder.append(getSQLOperator(expr.getOperator()));
+	    builder.append("(");
             expr.getRightArg().visit(this);
+	    builder.append(")");
             optypes.pop();
         }
     }

--- a/libraries/kiwi/kiwi-sparql/src/test/java/org/apache/marmotta/kiwi/sparql/test/KiWiSparqlTest.java
+++ b/libraries/kiwi/kiwi-sparql/src/test/java/org/apache/marmotta/kiwi/sparql/test/KiWiSparqlTest.java
@@ -296,13 +296,12 @@ public class KiWiSparqlTest {
         }
     }
 
-    /*
-    see https://issues.apache.org/jira/browse/MARMOTTA-628
+    
     @Test
     public void testMarmotta627_1() throws Exception {
         testMarmotta627("SELECT ( (4.5-4.4)*0.1 as ?c )  WHERE {}", 0.01);
     }
-    */
+    
 
     @Test
     public void testMarmotta627_2() throws Exception {


### PR DESCRIPTION
I've added parenthesis both for left and right side of an mathematical expression. Also I've uncommented the first test for Marmotta 627.