### PR TITLE
Marmotta-646: update marmotta-util-rdfpatch to RDF4J

### DIFF
--- a/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/pom.xml
+++ b/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.marmotta</groupId>
         <artifactId>marmotta-parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.3.0</version>
         <relativePath>../../../parent/</relativePath>
     </parent>
 
@@ -80,27 +80,30 @@
     </build>
 
     <dependencies>
-        <!-- data model -->
+        <!-- RDF4J data model -->
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-model</artifactId>
-        </dependency>
+		    <groupId>org.eclipse.rdf4j</groupId>
+		    <artifactId>rdf4j-model</artifactId>
+		    <version>2.0M2</version>
+		</dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-repository-api</artifactId>
-        </dependency>
+		    <groupId>org.eclipse.rdf4j</groupId>
+		    <artifactId>rdf4j-repository-api</artifactId>
+		    <version>2.0M2</version>
+		</dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-rio-turtle</artifactId>
+		    <groupId>org.eclipse.rdf4j</groupId>
+		    <artifactId>rdf4j-rio-turtle</artifactId>
+		    <version>2.0M2</version>
             <!-- rdf-patch only uses a single Util-Class from the turtle module -->
             <exclusions>
                 <exclusion>
-                    <groupId>org.openrdf.sesame</groupId>
-                    <artifactId>sesame-rio-datatypes</artifactId>
+				    <groupId>org.eclipse.rdf4j</groupId>
+				    <artifactId>rdf4j-rio-datatypes</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.openrdf.sesame</groupId>
-                    <artifactId>sesame-rio-languages</artifactId>
+                    <groupId>org.eclipse.rdf4j</groupId>
+    				<artifactId>rdf4j-rio-languages</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -138,13 +141,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-sail-memory</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+    		<artifactId>rdf4j-sail-memory</artifactId>
+    		<version>2.0M2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.openrdf.sesame</groupId>
-            <artifactId>sesame-repository-sail</artifactId>
+            <groupId>org.eclipse.rdf4j</groupId>
+		    <artifactId>rdf4j-repository-sail</artifactId>
+		    <version>2.0M2</version>
             <scope>test</scope>
         </dependency>
 

--- a/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/java/org/apache/marmotta/platform/ldp/patch/RdfPatchIO.java
+++ b/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/java/org/apache/marmotta/platform/ldp/patch/RdfPatchIO.java
@@ -19,8 +19,8 @@ package org.apache.marmotta.platform.ldp.patch;
 
 import org.apache.commons.io.output.StringBuilderWriter;
 import org.apache.marmotta.platform.ldp.patch.model.PatchLine;
-import org.openrdf.model.*;
-import org.openrdf.rio.turtle.TurtleUtil;
+import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.rio.turtle.TurtleUtil;
 
 import java.io.*;
 import java.util.Collections;
@@ -122,7 +122,7 @@ public class RdfPatchIO {
     private static String io(Value v, Map<String, String> inverseNamespaceMap) {
         if (v == null) {
             return "R";
-        } else if (v instanceof URI) {
+        } else if (v instanceof IRI) {
             final String uri = v.stringValue();
             String prefix = null;
 
@@ -148,8 +148,8 @@ public class RdfPatchIO {
             } else {
                 sb.append("\"").append(TurtleUtil.encodeString(label)).append("\"");
             }
-            if (l.getLanguage() != null) {
-                sb.append("@").append(l.getLanguage());
+            if (l.getLanguage() != null && l.getLanguage().isPresent()) {
+                sb.append("@").append(l.getLanguage().get());
             } else if (l.getDatatype() != null) {
                 sb.append("^^").append(io(l.getDatatype(), inverseNamespaceMap));
             }

--- a/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/java/org/apache/marmotta/platform/ldp/patch/RdfPatchUtil.java
+++ b/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/java/org/apache/marmotta/platform/ldp/patch/RdfPatchUtil.java
@@ -23,11 +23,11 @@ import org.apache.marmotta.platform.ldp.patch.model.WildcardStatement;
 import org.apache.marmotta.platform.ldp.patch.parser.ParseException;
 import org.apache.marmotta.platform.ldp.patch.parser.RdfPatchParser;
 import org.apache.marmotta.platform.ldp.patch.parser.RdfPatchParserImpl;
-import org.openrdf.model.*;
-import org.openrdf.repository.Repository;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.repository.RepositoryResult;
+import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.RepositoryResult;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/java/org/apache/marmotta/platform/ldp/patch/model/PatchLine.java
+++ b/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/java/org/apache/marmotta/platform/ldp/patch/model/PatchLine.java
@@ -17,8 +17,8 @@
  */
 package org.apache.marmotta.platform.ldp.patch.model;
 
-import org.openrdf.model.Statement;
-import org.openrdf.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
 
 /**
  * A single PatchLine, i.e. a operation of a Patch.

--- a/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/java/org/apache/marmotta/platform/ldp/patch/model/WildcardStatement.java
+++ b/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/java/org/apache/marmotta/platform/ldp/patch/model/WildcardStatement.java
@@ -18,10 +18,12 @@
 package org.apache.marmotta.platform.ldp.patch.model;
 
 import org.apache.commons.lang3.ObjectUtils;
-import org.openrdf.model.Resource;
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 /**
  * The Statement in a RdfPatch.
@@ -46,8 +48,11 @@ public class WildcardStatement implements Statement {
     }
 
     @Override
-    public URI getPredicate() {
-        return predicate;
+    public IRI getPredicate() {
+    	if (predicate != null)
+    		return SimpleValueFactory.getInstance().createIRI(predicate.toString());
+    	else
+    		return null;
     }
 
     @Override

--- a/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/java/org/apache/marmotta/platform/ldp/patch/parser/RdfPatchParser.java
+++ b/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/java/org/apache/marmotta/platform/ldp/patch/parser/RdfPatchParser.java
@@ -18,7 +18,7 @@
 package org.apache.marmotta.platform.ldp.patch.parser;
 
 import org.apache.marmotta.platform.ldp.patch.model.PatchLine;
-import org.openrdf.model.ValueFactory;
+import org.eclipse.rdf4j.model.ValueFactory;
 
 import java.util.List;
 

--- a/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/javacc/rdf-patch.jj
+++ b/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/main/javacc/rdf-patch.jj
@@ -31,9 +31,9 @@ package org.apache.marmotta.platform.ldp.patch.parser;
 
 import org.apache.marmotta.platform.ldp.patch.model.PatchLine;
 import org.apache.marmotta.platform.ldp.patch.model.WildcardStatement;
-import org.openrdf.model.*;
-import org.openrdf.model.impl.ValueFactoryImpl;
-import org.openrdf.rio.turtle.TurtleUtil;
+import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.turtle.TurtleUtil;
 
 import java.io.InputStream;
 import java.util.HashMap;
@@ -43,7 +43,7 @@ import java.util.List;
 public class RdfPatchParserImpl implements RdfPatchParser {
 
     private HashMap<String, String> namespaces = new HashMap<String, String>();
-    private ValueFactory valueFactory = ValueFactoryImpl.getInstance();
+    private ValueFactory valueFactory = SimpleValueFactory.getInstance();
 
     public RdfPatchParserImpl(ValueFactory vf, InputStream is) {
         this(is);
@@ -67,17 +67,17 @@ public class RdfPatchParserImpl implements RdfPatchParser {
     }
 
 
-    private URI createURI(String uri) {
-        return this.valueFactory.createURI(unwrapUri(uri));
+    private IRI createIRI(String uri) {
+        return this.valueFactory.createIRI(unwrapUri(uri));
     }
 
-    private URI createURI(String prefix, String local) {
-        return this.valueFactory.createURI(namespaces.get(prefix)+local);
+    private IRI createIRI(String prefix, String local) {
+        return this.valueFactory.createIRI(namespaces.get(prefix)+local);
     }
 
-    private URI createURIfromQname(String qname) {
+    private IRI createIRIfromQname(String qname) {
         final String[] split = qname.split(":", 2);
-        return createURI(split[0], split[1]);
+        return createIRI(split[0], split[1]);
     }
 
     private BNode createBNode(String id) {
@@ -216,6 +216,6 @@ private URI parseURI() : {
     Token u;
 }
 {
-    u = <URI> { return createURI(u.image); } |
-    u = <QNAME> { return createURIfromQname(u.image); }
+    u = <URI> { return createIRI(u.image); } |
+    u = <QNAME> { return createIRIfromQname(u.image); }
 }

--- a/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/test/java/org/apache/marmotta/platform/ldp/patch/RdfPatchIOTest.java
+++ b/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/test/java/org/apache/marmotta/platform/ldp/patch/RdfPatchIOTest.java
@@ -22,7 +22,7 @@ import org.apache.marmotta.platform.ldp.patch.parser.ParseException;
 import org.apache.marmotta.platform.ldp.patch.parser.RdfPatchParserImpl;
 import org.junit.Assert;
 import org.junit.Test;
-import org.openrdf.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 
 import java.io.StringReader;
 import java.util.Collections;

--- a/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/test/java/org/apache/marmotta/platform/ldp/patch/RdfPatchUtilTest.java
+++ b/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/test/java/org/apache/marmotta/platform/ldp/patch/RdfPatchUtilTest.java
@@ -25,15 +25,15 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.model.Literal;
-import org.openrdf.model.URI;
-import org.openrdf.model.vocabulary.FOAF;
-import org.openrdf.repository.Repository;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.repository.sail.SailRepository;
-import org.openrdf.rio.RDFFormat;
-import org.openrdf.sail.memory.MemoryStore;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.URI;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 import java.util.List;
 

--- a/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/test/java/org/apache/marmotta/platform/ldp/patch/parser/RdfPatchParserImplTest.java
+++ b/commons/marmotta-sesame-tools/marmotta-util-rdfpatch/src/test/java/org/apache/marmotta/platform/ldp/patch/parser/RdfPatchParserImplTest.java
@@ -22,10 +22,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openrdf.model.*;
-import org.openrdf.model.impl.LiteralImpl;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.*;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
 
 import java.util.Iterator;
 import java.util.List;
@@ -39,19 +38,21 @@ public class RdfPatchParserImplTest {
 
 
     private RdfPatchParserImpl parser;
-    private URI alice, bob, charlie;
+    private IRI alice, bob, charlie;
     private Literal lcBob, ucBob;
 
     @Before
     public void setUp() {
         parser = new RdfPatchParserImpl(this.getClass().getResourceAsStream("/illustrative.rdfp"));
+        
+        ValueFactory f = SimpleValueFactory.getInstance();
 
-        alice = new URIImpl("http://example/alice");
-        bob = new URIImpl("http://example/bob");
-        charlie = new URIImpl("http://example/charlie");
+        alice = f.createIRI("http://example/alice");
+        bob = f.createIRI("http://example/bob");
+        charlie = f.createIRI("http://example/charlie");
 
-        lcBob = new LiteralImpl("bob");
-        ucBob = new LiteralImpl("Bob");
+        lcBob = f.createLiteral("bob");
+        ucBob = f.createLiteral("Bob");
     }
 
     @After
@@ -79,7 +80,7 @@ public class RdfPatchParserImplTest {
         checkPatchLine(it.next(), PatchLine.Operator.DELETE, null, null, charlie);
     }
 
-    private void checkPatchLine(PatchLine line, PatchLine.Operator operator, Resource subejct, URI predicate, Value object) {
+    private void checkPatchLine(PatchLine line, PatchLine.Operator operator, Resource subejct, IRI predicate, Value object) {
         Assert.assertEquals("Wrong patch operation", operator, line.getOperator());
 
         Statement statement = line.getStatement();


### PR DESCRIPTION
Migration of marmotta-util-rdfpatch module from OpenRDF Sesame library to Eclipse RDF4J.
Forked project repository: [marmotta-rdf4j](https://github.com/sisinflab-swot/marmotta-rdf4j)
