### PR TITLE
Solved MARMOTTA-657 - SPARQL query GROUP BY with ORDER BY clause fails.

### DIFF
--- a/libraries/kiwi/kiwi-sparql/src/test/java/org/apache/marmotta/kiwi/sparql/test/KiWiSparqlTest.java
+++ b/libraries/kiwi/kiwi-sparql/src/test/java/org/apache/marmotta/kiwi/sparql/test/KiWiSparqlTest.java
@@ -20,19 +20,37 @@ package org.apache.marmotta.kiwi.sparql.test;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import info.aduna.iteration.Iterations;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.marmotta.kiwi.config.KiWiConfiguration;
 import org.apache.marmotta.kiwi.sail.KiWiStore;
 import org.apache.marmotta.kiwi.sparql.sail.KiWiSparqlSail;
 import org.apache.marmotta.kiwi.test.junit.KiWiDatabaseRunner;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.openrdf.model.BNode;
 import org.openrdf.model.Literal;
-import org.openrdf.query.*;
+import org.openrdf.query.Binding;
+import org.openrdf.query.BindingSet;
+import org.openrdf.query.GraphQuery;
+import org.openrdf.query.GraphQueryResult;
+import org.openrdf.query.MalformedQueryException;
+import org.openrdf.query.QueryEvaluationException;
+import org.openrdf.query.QueryLanguage;
+import org.openrdf.query.TupleQuery;
+import org.openrdf.query.TupleQueryResult;
 import org.openrdf.repository.Repository;
 import org.openrdf.repository.RepositoryConnection;
 import org.openrdf.repository.RepositoryException;
@@ -42,12 +60,6 @@ import org.openrdf.rio.RDFParseException;
 import org.openrdf.sail.memory.MemoryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Test the KiWi SPARQL
@@ -132,6 +144,15 @@ public class KiWiSparqlTest {
         testQueryCompareResults("MARMOTTA-578.sparql");
     }
 
+    /**
+     * Tests if evaluation of query executes. Solves MARMOTTA-657.
+     * @throws Exception 
+     */
+    @Test
+    public void testMarmotta657() throws Exception{
+        final String queryString = IOUtils.toString(this.getClass().getResourceAsStream("MARMOTTA-657.sparql"), "UTF-8");
+        testQueryEvaluation(queryString);
+    }
     //TODO: generalize this infrastructure code also used by KiWiSparqlJoinTest
 
     private void testQueryCompareResults(String filename) throws Exception {

--- a/libraries/kiwi/kiwi-sparql/src/test/resources/org/apache/marmotta/kiwi/sparql/test/MARMOTTA-657.sparql
+++ b/libraries/kiwi/kiwi-sparql/src/test/resources/org/apache/marmotta/kiwi/sparql/test/MARMOTTA-657.sparql
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+SELECT ?g (COUNT(*) AS ?c) {
+  GRAPH ?g {
+    ?s ?p ?o
+  }
+}
+GROUP BY ?g
+ORDER BY DESC(?c)


### PR DESCRIPTION
When building a SQL query, GROUP BY statements allow aggregate functions. This was solved comparing if an statement from ORDER BY is not an aggregate funtion, then add if not continue. This PR solves MARMOTTA-657.

Be sure to do all of the following to help us incorporate your contribution quickly and easily:

 - [x] Make sure the PR title is formatted like: `MARMOTTA-XXX: title of pull request`
   (replace `XXX` in the title with the actual Jira issue number; if there is no one,
   please [create one](https://issues.apache.org/jira/browse/MARMOTTA) before).
 - [x] Make sure tests pass via mvn clean verify (even better, enable Travis-CI on your
   fork and ensure the whole test suite passes).
 - [ ] If this contribution is large, please file an 
   [Apache's Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

