### PR TITLE
MARMOTTA-667

### DIFF
--- a/platform/backends/marmotta-backend-titan/pom.xml
+++ b/platform/backends/marmotta-backend-titan/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>com.tinkerpop.blueprints</groupId>
             <artifactId>blueprints-graph-sail</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixes 'the getContextIDs operation is not yet supported' because of outdated blueprints-graph-sail (2.4.0) in titan DB backend.

